### PR TITLE
fix: docs on require config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm install -D dotenv
 In `gatsby-config.js`:
 
 ```
-require("dotenv").require()
+require("dotenv").config()
 
 module.exports = {
   ...


### PR DESCRIPTION
Noticed a typo in the `require('dotenv').config()` in README. This PR fixes it.

See - https://www.npmjs.com/package/dotenv#usage